### PR TITLE
Changelog updates to reflect aws-ec2 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,12 +73,18 @@ FEATURES:
    [Circonus](http://www.circonus.com/). See the [configuration
    documentation](https://www.vaultproject.io/docs/config/index.html) for
    details. [GH-1646]
+ * **AWS-EC2 Authentication Backed**: The AWS-EC2 authentication backend has been 
+   updated to allow additional constaraints of `bound_account_id` or `bound_iam_role_arn`. 
+   Effectively this enables authenication from one (or more) of an instances AMI ID, Account ID 
+   OR IAM Role ARN. [GH-1522] [GH-1523]
 
 IMPROVEMENTS:
 
  * audit: Added a unique identifier to each request which will also be found in
    the request portion of the response. [GH-1650]
- * auth/aws-ec2: Added a new constraint, 'bound_account_id' to the role
+ * auth/aws-ec2: Added a new constraint, `bound_iam_role_arn` to the role 
+   [GH-1522]
+ * auth/aws-ec2: Added a new constraint, `bound_account_id` to the role
    [GH-1523]
  * auth/aws-ec2: Added `ttl` field for the role [GH-1703]
  * auth/ldap, secret/cassandra, physical/consul: Clients with `tls.Config`


### PR DESCRIPTION
There were some changes to the `aws-ec2` auth backend that were exactly what I was looking for but didn't realize they had been implemented in the 0.6.1 RC branches until I dug into the code. 

Just adding in some docs to the CHANGELOG.md for those of us who pay attention to these things to spot the great work that's being done.
